### PR TITLE
feat: replace banner carousel with single static image

### DIFF
--- a/src/components/CarouselBanner.tsx
+++ b/src/components/CarouselBanner.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface Slide {
+  image: string;
+}
+
+interface CarouselBannerProps {
+  slides: Slide[];
+}
+
+const CarouselBanner: React.FC<CarouselBannerProps> = ({ slides }) => {
+  if (!slides.length) return null;
+
+  const slide = slides[0];
+
+  return (
+    <section className="relative w-full h-64 md:h-96 lg:h-[500px]">
+      <img
+        src={slide.image}
+        alt="Promoção"
+        className="w-full h-full object-cover"
+      />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <button className="bg-red-600 hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-800 text-white font-semibold px-6 py-3 rounded-full shadow-lg transform transition-all hover:scale-105">
+          Garanta já
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default CarouselBanner;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import HeroSection from '../components/HeroSection';
+import CarouselBanner from '../components/CarouselBanner';
 import DogSizeBanners from '../components/DogSizeBanners';
 import BestSellersCarousel from '../components/BestSellersCarousel';
 import { products } from '../data/products';
@@ -11,7 +11,13 @@ const HomePage: React.FC = () => {
 
   return (
     <>
-      <HeroSection />
+      <CarouselBanner
+        slides={[
+          {
+            image: 'https://drive.google.com/uc?export=view&id=1a-76S9qtuRj_oQ54lUV-RGA-bklLi98W',
+          },
+        ]}
+      />
       <DogSizeBanners />
       {bestSellers.length > 0 && <BestSellersCarousel products={bestSellers} />}
     </>


### PR DESCRIPTION
## Summary
- add CarouselBanner component showing static promotional image with call-to-action button
- update HomePage to render single-slide banner carousel

## Testing
- `npm run lint` *(fails: formatPrice unused variables in other pages)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca647c47c8332ba57f4a9b8d26105